### PR TITLE
ExternalLink, InternalLinkコンポーネントを作成

### DIFF
--- a/frontend/src/components/common/ExternalLink.tsx
+++ b/frontend/src/components/common/ExternalLink.tsx
@@ -1,0 +1,18 @@
+import { Link as ChakraLink } from '@chakra-ui/react'
+import { ComponentProps } from 'react'
+
+type Props = Omit<
+  ComponentProps<typeof ChakraLink>,
+  'isExternal' | 'target' | 'rel'
+> & { noreferrer?: boolean }
+
+export const ExternalLink = (props: Props) => {
+  const { noreferrer, ...others } = props
+  return (
+    <ChakraLink
+      target='_blank'
+      rel={noreferrer ? 'noopener noreferrer' : 'noopener'}
+      {...others}
+    />
+  )
+}

--- a/frontend/src/components/common/InternalLink.tsx
+++ b/frontend/src/components/common/InternalLink.tsx
@@ -1,0 +1,13 @@
+import { Link as ChakraLink } from '@chakra-ui/react'
+import { ComponentProps } from 'react'
+import { Link as ReactRouterLink } from 'react-router-dom'
+
+type Props = Omit<
+  ComponentProps<typeof ChakraLink>,
+  'href' | 'as' | 'isExternal'
+> &
+  ComponentProps<typeof ReactRouterLink>
+
+export const InternalLink = (props: Props) => {
+  return <ChakraLink as={ReactRouterLink} isExternal={false} {...props} />
+}

--- a/frontend/src/components/links/LinksPageComponents.tsx
+++ b/frontend/src/components/links/LinksPageComponents.tsx
@@ -1,5 +1,6 @@
 import { Heading } from '@chakra-ui/react'
 import { ReactNode } from 'react'
+import { ExternalLink } from '../common/ExternalLink'
 
 type Props = {
   children: ReactNode
@@ -13,9 +14,7 @@ export const LinksPageComponent = (props: Props) => {
   return (
     <div>
       <Heading as='h4' size='md'>
-        <a href={href} target='_blank' rel='noopener noreferrer'>
-          {title}
-        </a>
+        <ExternalLink href={href}>{title}</ExternalLink>
       </Heading>
       <p>{children}</p>
     </div>

--- a/frontend/src/components/navbar/TopBar.tsx
+++ b/frontend/src/components/navbar/TopBar.tsx
@@ -1,6 +1,6 @@
 import { Link as ReactRouterLink } from 'react-router-dom'
 import { Box, Flex, HStack, useColorModeValue } from '@chakra-ui/react'
-import { TopBarLink } from './TopBaLink'
+import { TopBarLink } from './TopBarLink'
 
 export const TopBar = () => {
   return (

--- a/frontend/src/components/navbar/TopBarLink.tsx
+++ b/frontend/src/components/navbar/TopBarLink.tsx
@@ -1,9 +1,5 @@
-import { Link } from '@chakra-ui/react'
-import {
-  Link as ReactRouterLink,
-  useLocation,
-  useMatch,
-} from 'react-router-dom'
+import { useLocation, useMatch } from 'react-router-dom'
+import { InternalLink } from '../common/InternalLink'
 
 type Props = {
   to: string
@@ -16,10 +12,9 @@ export const TopBarLink = (props: Props) => {
   const isActive = !!useMatch(to)
 
   return (
-    <Link
+    <InternalLink
       paddingX={2}
       paddingY={1}
-      as={ReactRouterLink}
       to={{ pathname: to, search: search }}
       _hover={{
         textDecoration: 'none',
@@ -27,6 +22,6 @@ export const TopBarLink = (props: Props) => {
       color={isActive ? 'green.500' : undefined}
     >
       {title}
-    </Link>
+    </InternalLink>
   )
 }

--- a/frontend/src/consumers/task/TaskAizuOnlineJudgeLink.tsx
+++ b/frontend/src/consumers/task/TaskAizuOnlineJudgeLink.tsx
@@ -1,7 +1,7 @@
 import { ElementType, useMemo } from 'react'
 import { getAizuOnlineJudgeUrl } from '../../helpers/url'
 import { useTask } from '../../hooks/contexts/TaskContext'
-import { Link } from '@chakra-ui/react'
+import { ExternalLink } from '../../components/common/ExternalLink'
 
 type Props = {
   as?: ElementType
@@ -20,15 +20,13 @@ export const TaskAizuOnlineJudgeLink = (props: Props) => {
 
   return (
     <Tag className={className}>
-      <Link
+      <ExternalLink
         color='teal.500'
         _hover={{ textDecoration: 'none' }}
         href={url}
-        target='_blank'
-        rel='noopener noreferrer'
       >
         {'★'}
-      </Link>
+      </ExternalLink>
     </Tag>
   )
 }

--- a/frontend/src/consumers/task/TaskName.tsx
+++ b/frontend/src/consumers/task/TaskName.tsx
@@ -1,7 +1,7 @@
 import { ElementType, useMemo } from 'react'
 import { getAtcoderUrl } from '../../helpers/url'
 import { useTask } from '../../hooks/contexts/TaskContext'
-import { Link } from '@chakra-ui/react'
+import { ExternalLink } from '../../components/common/ExternalLink'
 
 type Props = {
   as?: ElementType
@@ -21,15 +21,13 @@ export const TaskName = (props: Props) => {
 
   return (
     <Tag className={className}>
-      <Link
+      <ExternalLink
         color='teal.500'
         _hover={{ textDecoration: 'none' }}
         href={url}
-        target='_blank'
-        rel='noopener noreferrer'
       >
         {name}
-      </Link>
+      </ExternalLink>
     </Tag>
   )
 }


### PR DESCRIPTION
`Link`がChakraUIとReactRouterDOMで被って分かりづらいので、Linkコンポーネントを作成した

`noreferrer`は基本的には付けない方針でいく