### PR TITLE
Safariでも統計画像のコピーが出来るように修正

### DIFF
--- a/src/components/common/CopyImageButton.jsx
+++ b/src/components/common/CopyImageButton.jsx
@@ -7,25 +7,29 @@ class CopyImageButton extends React.Component {
     super(props)
   }
 
+  async getImageBlob(target) {
+    const canvas = await html2canvas(target, {
+      ignoreElements: (elem) => elem.tagName === 'BUTTON',
+      windowWidth: 10000,
+    })
+
+    const blob = await new Promise((resolve, reject) => {
+      try {
+        canvas.toBlob((blob) => resolve(blob), 'image/png')
+      } catch (e) {
+        reject(e)
+      }
+    })
+
+    return blob
+  }
+
   async copyToClipboard() {
     const { target } = this.props
 
     try {
-      const canvas = await html2canvas(target, {
-        ignoreElements: (elem) => elem.tagName === 'BUTTON',
-        windowWidth: 10000,
-      })
-
-      const blob = await new Promise((resolve, reject) => {
-        try {
-          canvas.toBlob((blob) => resolve(blob), 'image/png')
-        } catch (e) {
-          reject(e)
-        }
-      })
-
       await navigator.clipboard.write([
-        new ClipboardItem({ 'image/png': blob })
+        new ClipboardItem({ 'image/png': this.getImageBlob(target) })
       ])
       window.alert('統計画像をクリップボードにコピーしました')
     } catch(e) {


### PR DESCRIPTION
Promiseを渡すようにすることで解決した

参考
https://bugs.webkit.org/show_bug.cgi?id=222262