### PR TITLE
フロントエンドのテストを修正

### DIFF
--- a/frontend/src/components/navbar/TopBar.test.tsx
+++ b/frontend/src/components/navbar/TopBar.test.tsx
@@ -20,7 +20,7 @@ test.each([
   { name: 'History', to: '/history' },
   { name: 'ChangeLog', to: '/changelog' },
   { name: 'Links', to: '/links' },
-])('PCで${name}ページへのリンクが表示されている', async ({ name, to }) => {
+])('PCで$nameページへのリンクが表示されている', async ({ name, to }) => {
   setMedia({ width: '1000px' })
   const { getByRole } = render(
     <MemoryRouter>
@@ -55,10 +55,10 @@ test.each([
   { name: 'ChangeLog', to: '/changelog' },
   { name: 'Links', to: '/links' },
 ])(
-  'モバイルでボタンをクリックすると${name}ページへのリンクが表示される',
+  'モバイルでボタンをクリックすると$nameページへのリンクが表示される',
   async ({ name, to }) => {
     setMedia({ width: '400px' })
-    const { getByRole, user } = render(
+    const { getByRole, findByRole, user } = render(
       <MemoryRouter>
         <TopBar />
       </MemoryRouter>,
@@ -67,7 +67,7 @@ test.each([
     const button = getByRole('button')
     await user.click(button)
 
-    const link = within(getByRole('navigation')).getByRole('link', {
+    const link = within(await findByRole('navigation')).getByRole('link', {
       name,
     })
     expect(link).toBeInTheDocument()

--- a/frontend/src/test/vitest.setup.ts
+++ b/frontend/src/test/vitest.setup.ts
@@ -1,10 +1,9 @@
-import jestDomMatchers from '@testing-library/jest-dom/matchers'
+import '@testing-library/jest-dom'
 import { cleanup } from '@testing-library/react'
 import { matchers as emotionMatchers } from '@emotion/jest'
 import { afterEach, expect } from 'vitest'
 import { matchMedia, cleanup as cleanupMatchMedia } from 'mock-match-media'
 
-expect.extend(jestDomMatchers)
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 expect.extend(emotionMatchers)


### PR DESCRIPTION
- テスト名の修正
- jest-domの読み込み方法の修正
- navigationが開くまでの待ち時間により落ちていたテストの修正