### PR TITLE
幅が狭い場合にテーブルのみが横スクロールになるように修正

### DIFF
--- a/frontend/src/components/changelog/ChangeLog.tsx
+++ b/frontend/src/components/changelog/ChangeLog.tsx
@@ -1,5 +1,6 @@
 import { createColumnHelper, TableFeature } from '@tanstack/react-table'
 import { useMemo } from 'react'
+import { TableContainer } from '@chakra-ui/react'
 import { useChangeLog } from '../../hooks/http/changeLog'
 import { ChangeLogRecord } from '../../types/changeLog'
 import { useTasks } from '../../hooks/http/task'
@@ -7,7 +8,6 @@ import { Task } from '../../types/task'
 import { getAtcoderUrl } from '../../helpers/url'
 import { ExternalLink } from '../common/ExternalLink'
 import { DataTable } from '../common/DataTable'
-import { TableContainer } from '@chakra-ui/react'
 
 export const ChangeLog = () => {
   const { data: originalChangelog } = useChangeLog()

--- a/frontend/src/components/changelog/ChangeLog.tsx
+++ b/frontend/src/components/changelog/ChangeLog.tsx
@@ -7,6 +7,7 @@ import { Task } from '../../types/task'
 import { getAtcoderUrl } from '../../helpers/url'
 import { ExternalLink } from '../common/ExternalLink'
 import { DataTable } from '../common/DataTable'
+import { TableContainer } from '@chakra-ui/react'
 
 export const ChangeLog = () => {
   const { data: originalChangelog } = useChangeLog()
@@ -27,12 +28,14 @@ export const ChangeLog = () => {
   }
 
   return (
-    <DataTable
-      size='sm'
-      data={changelog}
-      columns={columns}
-      _features={changelogTableFeatures}
-    />
+    <TableContainer>
+      <DataTable
+        size='sm'
+        data={changelog}
+        columns={columns}
+        _features={changelogTableFeatures}
+      />
+    </TableContainer>
   )
 }
 

--- a/frontend/src/components/difficultyList/DifficultyList.tsx
+++ b/frontend/src/components/difficultyList/DifficultyList.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { createColumnHelper, TableFeature } from '@tanstack/react-table'
 import { match } from 'ts-pattern'
+import { TableContainer } from '@chakra-ui/react'
 import { useTasks } from '../../hooks/http/task'
 import { mergeTaskAndSubmissions } from '../../helpers/submission'
 import { TaskFilter, TaskWithResult } from '../../types/task'
@@ -9,7 +10,6 @@ import { Submission } from '../../types/submission'
 import { ExternalLink } from '../common/ExternalLink'
 import { DataTable } from '../common/DataTable'
 import { getAizuOnlineJudgeUrl, getAtcoderUrl } from '../../helpers/url'
-import { TableContainer } from '@chakra-ui/react'
 
 type Props = {
   submissions?: Submission[]

--- a/frontend/src/components/difficultyList/DifficultyList.tsx
+++ b/frontend/src/components/difficultyList/DifficultyList.tsx
@@ -9,6 +9,7 @@ import { Submission } from '../../types/submission'
 import { ExternalLink } from '../common/ExternalLink'
 import { DataTable } from '../common/DataTable'
 import { getAizuOnlineJudgeUrl, getAtcoderUrl } from '../../helpers/url'
+import { TableContainer } from '@chakra-ui/react'
 
 type Props = {
   submissions?: Submission[]
@@ -33,12 +34,14 @@ export const DifficultyList = (props: Props) => {
   }, [rivalSubmissions, submissions, filteredTasks])
 
   return (
-    <DataTable
-      size={'sm'}
-      data={tasksWithResult}
-      columns={columns}
-      _features={difficultyListTableFeatures}
-    />
+    <TableContainer>
+      <DataTable
+        size={'sm'}
+        data={tasksWithResult}
+        columns={columns}
+        _features={difficultyListTableFeatures}
+      />
+    </TableContainer>
   )
 }
 


### PR DESCRIPTION
幅が狭い場合にテーブルがはみ出して、ページ全体が横方向にスクロール用になったため、テーブルのみが横スクロールになるように修正